### PR TITLE
[PAM-1392] Preserve reportee on updates of approved ads

### DIFF
--- a/app/src/main/java/no/nav/pam/annonsemottak/annonsemottak/fangst/DuplicateHandler.java
+++ b/app/src/main/java/no/nav/pam/annonsemottak/annonsemottak/fangst/DuplicateHandler.java
@@ -3,12 +3,15 @@ package no.nav.pam.annonsemottak.annonsemottak.fangst;
 import no.nav.pam.annonsemottak.annonsemottak.solr.SolrService;
 import no.nav.pam.annonsemottak.annonsemottak.solr.StillingSolrBean;
 import no.nav.pam.annonsemottak.annonsemottak.solr.fetch.StillingSolrBeanFieldNames;
+import no.nav.pam.annonsemottak.stilling.IllegalSaksbehandlingCommandException;
+import no.nav.pam.annonsemottak.stilling.OppdaterSaksbehandlingCommand;
 import no.nav.pam.annonsemottak.stilling.Stilling;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -48,6 +51,11 @@ public class DuplicateHandler {
         LOG.debug("Got duplicate arbeidsgiver: " + stillingSolrBean.getArbeidsgivernavn() +
                 " tittel: "+ stillingSolrBean.getTittel() + " id: " + stillingSolrBean.getId());
         stilling.rejectAsDuplicate(stillingSolrBean.getId());
+        try {
+            stilling.oppdaterMed(new OppdaterSaksbehandlingCommand(Collections.singletonMap("saksbehandler", "System")));
+        } catch (IllegalSaksbehandlingCommandException e) {
+            throw new IllegalStateException("Unexpceted error when updating ad reportee", e);
+        }
     }
 
     private List<StillingSolrBean> search(Stilling stilling) {

--- a/app/src/main/java/no/nav/pam/annonsemottak/stilling/Stilling.java
+++ b/app/src/main/java/no/nav/pam/annonsemottak/stilling/Stilling.java
@@ -333,10 +333,9 @@ public class Stilling extends ModelEntity {
     public Stilling merge(Stilling stilling) {
         Status oldStatus = stilling.getSaksbehandling().getStatus();
 
+        this.saksbehandling = stilling.getSaksbehandling();
         if ((oldStatus == Status.GODKJENT || oldStatus == Status.FJERNET) && this.annonseStatus != AnnonseStatus.STOPPET) {
             this.getSaksbehandling().oppdatert();
-        } else {
-            this.saksbehandling = stilling.getSaksbehandling();
         }
         this.setId(stilling.getId());
         this.uuid = stilling.getUuid();

--- a/app/src/test/java/no/nav/pam/annonsemottak/annonsemottak/fangst/DuplicateHandlerTest.java
+++ b/app/src/test/java/no/nav/pam/annonsemottak/annonsemottak/fangst/DuplicateHandlerTest.java
@@ -1,40 +1,44 @@
 package no.nav.pam.annonsemottak.annonsemottak.fangst;
 
-import no.nav.pam.annonsemottak.annonsemottak.solr.SolrRepository;
 import no.nav.pam.annonsemottak.annonsemottak.solr.SolrService;
-import no.nav.pam.annonsemottak.stilling.Merknader;
+import no.nav.pam.annonsemottak.annonsemottak.solr.StillingSolrBean;
 import no.nav.pam.annonsemottak.stilling.Status;
 import no.nav.pam.annonsemottak.stilling.Stilling;
 import no.nav.pam.annonsemottak.stilling.StillingTestdataBuilder;
-import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.solr.client.solrj.SolrServer;
-import org.apache.solr.client.solrj.impl.HttpSolrServer;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-@Ignore
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class DuplicateHandlerTest {
 
-
     @Test
-    public void testDuplicates() throws Exception {
-        Stilling noMatch = StillingTestdataBuilder.enkelStilling().build();
-        Stilling dupe = StillingTestdataBuilder.stilling().arbeidsgiver("SPIRONORGE AS").tittel("lager/sjøfør/ produksjonsmedarbeider").build();
+    public void testSystemReporteeSetWhenMarkingAsDuplicate() {
+        SolrService solrService = mock(SolrService.class);
+        StillingSolrBean existing = new StillingSolrBean();
+        existing.setId(1000);
+        existing.setArbeidsgivernavn("ACME Corp.");
+        existing.setTittel("Job");
+        when(solrService.searchStillinger(any())).thenReturn(Collections.singletonList(existing));
+
+        DuplicateHandler handler = new DuplicateHandler(solrService);
+
         AnnonseResult result = new AnnonseResult();
-        result.getNewList().add(noMatch);
-        result.getNewList().add(dupe);
-        String url = "https://itjenester-t1.oera.no/stilling-solr/maincore";
-        HttpClient httpClient = HttpClientBuilder.create().disableCookieManagement().build();
-        SolrServer solrServer = new HttpSolrServer(url, httpClient);
-        SolrRepository repository = new SolrRepository(solrServer);
-        SolrService solrService = new SolrService(repository);
-        DuplicateHandler duplicateHandler = new DuplicateHandler(solrService);
-        duplicateHandler.markDuplicates(result);
-        Assert.assertEquals(1, result.getDuplicateList().size());
-        Assert.assertEquals(Status.AVVIST, dupe.getStatus());
-        Assert.assertEquals(result.getNewList().size(), 1);
-        Assert.assertEquals(Merknader.Merknad.DUPLIKAT.getKodeAsString(), dupe.getMerknader().get().asString());
-        System.out.println(dupe.getStatus().toString() + " " + dupe.getMerknader().get().asString() + " "+dupe.getKommentarer().get().asString());
+        result.getNewList().add(StillingTestdataBuilder.enkelStilling().arbeidsgiver("ACME Corp.").tittel("Job").build());
+
+        handler.markDuplicates(result);
+
+        assertThat(result.getDuplicateList().size()).isEqualTo(1);
+
+        Stilling duplicate = result.getDuplicateList().get(0);
+        assertThat(duplicate.getSaksbehandler().isPresent()).isTrue();
+        assertThat(duplicate.getSaksbehandler().get().asString()).isEqualTo("System");
+        assertThat(duplicate.getStatus()).isEqualTo(Status.AVVIST);
     }
+
+
 }

--- a/app/src/test/java/no/nav/pam/annonsemottak/annonsemottak/fangst/DuplicateHandlerTestIntegration.java
+++ b/app/src/test/java/no/nav/pam/annonsemottak/annonsemottak/fangst/DuplicateHandlerTestIntegration.java
@@ -1,0 +1,40 @@
+package no.nav.pam.annonsemottak.annonsemottak.fangst;
+
+import no.nav.pam.annonsemottak.annonsemottak.solr.SolrRepository;
+import no.nav.pam.annonsemottak.annonsemottak.solr.SolrService;
+import no.nav.pam.annonsemottak.stilling.Merknader;
+import no.nav.pam.annonsemottak.stilling.Status;
+import no.nav.pam.annonsemottak.stilling.Stilling;
+import no.nav.pam.annonsemottak.stilling.StillingTestdataBuilder;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrServer;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+@Ignore
+public class DuplicateHandlerTestIntegration {
+
+
+    @Test
+    public void testDuplicates() throws Exception {
+        Stilling noMatch = StillingTestdataBuilder.enkelStilling().build();
+        Stilling dupe = StillingTestdataBuilder.stilling().arbeidsgiver("SPIRONORGE AS").tittel("lager/sjøfør/ produksjonsmedarbeider").build();
+        AnnonseResult result = new AnnonseResult();
+        result.getNewList().add(noMatch);
+        result.getNewList().add(dupe);
+        String url = "https://itjenester-t1.oera.no/stilling-solr/maincore";
+        HttpClient httpClient = HttpClientBuilder.create().disableCookieManagement().build();
+        SolrServer solrServer = new HttpSolrServer(url, httpClient);
+        SolrRepository repository = new SolrRepository(solrServer);
+        SolrService solrService = new SolrService(repository);
+        DuplicateHandler duplicateHandler = new DuplicateHandler(solrService);
+        duplicateHandler.markDuplicates(result);
+        Assert.assertEquals(1, result.getDuplicateList().size());
+        Assert.assertEquals(Status.AVVIST, dupe.getStatus());
+        Assert.assertEquals(result.getNewList().size(), 1);
+        Assert.assertEquals(Merknader.Merknad.DUPLIKAT.getKodeAsString(), dupe.getMerknader().get().asString());
+        System.out.println(dupe.getStatus().toString() + " " + dupe.getMerknader().get().asString() + " "+dupe.getKommentarer().get().asString());
+    }
+}


### PR DESCRIPTION
Administration status is only mapped in pam-ad when a reportee is set.

Ensure reportee is kept on ads in GODKJENT state, when transitioning
to OPPDATERT for ad updates. This in turns causes correct
administration state to be propagated to pam-ad (keeping the status
DONE).

Also, when system marks ads as duplicates, set reportee to "System",
for the same reason as above.

https://jira.adeo.no/browse/PAM-1392