### PR TITLE
Lagt til separat feature toggle for å kunne deaktivere henting av solr-stillinger. 

### DIFF
--- a/src/main/java/no/nav/pam/annonsemottak/receivers/solr/fetch/SolrFetchService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/solr/fetch/SolrFetchService.java
@@ -70,7 +70,7 @@ public class SolrFetchService {
 
     private static String fraArbeidsgiverPart() {
 
-        if(toggle("pam.schedule.fetch.from.xmlstilling").isDisabled()) {
+        if(toggle("pam.schedule.fetch.from.xmlstilling.via.solr").isDisabled()) {
             return "\"" + fraArbeidsgiver + "\"" +
                     " OR ";
         }

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/solr/fetch/SolrFetchService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/solr/fetch/SolrFetchService.java
@@ -70,7 +70,7 @@ public class SolrFetchService {
 
     private static String fraArbeidsgiverPart() {
 
-        if(toggle("pam.schedule.fetch.from.xmlstilling.via.solr").isDisabled()) {
+        if(toggle("pam.schedule.disable.fetch.from.xmlstilling.via.solr").isDisabled()) {
             return "\"" + fraArbeidsgiver + "\"" +
                     " OR ";
         }

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/solr/fetch/StopSolrStillingerService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/solr/fetch/StopSolrStillingerService.java
@@ -35,7 +35,7 @@ public class StopSolrStillingerService {
     @Deprecated
     private Predicate<Stilling> ignoreOverfortFraArbeidsgiver = s -> {
 
-        if(toggle("pam.schedule.fetch.from.xmlstilling.via.solr").isEnabled()) {
+        if(toggle("pam.schedule.disable.fetch.from.xmlstilling.via.solr").isEnabled()) {
             return !s.getMedium().equals(fraArbeidsgiver);
         }
 

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/solr/fetch/StopSolrStillingerService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/solr/fetch/StopSolrStillingerService.java
@@ -35,7 +35,7 @@ public class StopSolrStillingerService {
     @Deprecated
     private Predicate<Stilling> ignoreOverfortFraArbeidsgiver = s -> {
 
-        if(toggle("pam.schedule.fetch.from.xmlstilling").isEnabled()) {
+        if(toggle("pam.schedule.fetch.from.xmlstilling.via.solr").isEnabled()) {
             return !s.getMedium().equals(fraArbeidsgiver);
         }
 


### PR DESCRIPTION
Lagt til separat feature toggle (pam.schedule.disable.fetch.from.xmlstilling.via.solr)) for å kunne deaktivere henting av solr-stillinger. De ha trenger samme enabled/disabled-statuser som den gamle pam.schedule.fetch.from.xmlstilling