### PR TITLE
Stillinger med source lik nav fra amedia filtreres bort

### DIFF
--- a/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaDateConverter.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaDateConverter.java
@@ -12,23 +12,25 @@ import java.time.format.DateTimeFormatter;
 class AmediaDateConverter {
 
     private static final String AMEDIA_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ssZ";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(AMEDIA_DATE_PATTERN);
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Z");
 
 
-    static LocalDateTime convertDate(String date) {
+    static LocalDateTime convertDate(final String date) {
         if (StringUtils.isBlank(date)) {
             return null;
         }
 
-        date = date.replace("Z", "+0000");
-        return LocalDateTime.parse(date, DateTimeFormatter.ofPattern(AMEDIA_DATE_PATTERN));
+        String parseableAmediaDate = date.replace("Z", "+0000");
+        return LocalDateTime.parse(parseableAmediaDate, DateTimeFormatter.ofPattern(AMEDIA_DATE_PATTERN));
     }
 
-    static String toStringUrlEncoded(LocalDateTime date) {
+    static String toStringUrlEncoded(final LocalDateTime date) {
+        return urlEncode(date.atZone(DEFAULT_ZONE).format(DATE_TIME_FORMATTER));
+    }
 
-        String dateValue = date.atZone(ZoneId.of("Z")).format(DateTimeFormatter.ofPattern(AMEDIA_DATE_PATTERN));
-        return dateValue
-                .replace("+0000", "Z")
-                .replace(":", "%5C:");
+    private static String urlEncode(final String s) {
+        return s.replace("+0000", "Z").replace(":", "%5C:");
     }
 
     static LocalDateTime getInitialDate() {

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaFieldTransformer.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaFieldTransformer.java
@@ -11,6 +11,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
+
 class AmediaFieldTransformer {
 
     static final String IKKE_OPPGITT = "Ikke oppgitt";
@@ -50,7 +52,7 @@ class AmediaFieldTransformer {
 
     List<String> hentListeSomStrenger(JsonNode node) {
         if (node == null) {
-            return Collections.emptyList();
+            return emptyList();
         }
         return Lists.newArrayList(node.iterator()).stream()
                 .map(JsonNode::toString)
@@ -59,7 +61,7 @@ class AmediaFieldTransformer {
 
     List<JsonNode> hentListeSomJsonnoder(JsonNode node) {
         if (node == null) {
-            return Collections.emptyList();
+            return emptyList();
         }
         return Lists.newArrayList(node.iterator());
     }

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaRequestParametere.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaRequestParametere.java
@@ -28,7 +28,12 @@ public class AmediaRequestParametere {
     private final String maxAntallTreff;
     private final String medInnhold;
 
-    public AmediaRequestParametere(LocalDateTime sisteModifiedDate, boolean medInnhold, int resultSize) {
+
+    private static final LocalDateTime DAWN_OF_TIME_LOCALDATETIME = LocalDateTime.of(1900, 1, 1, 0, 0, 0);
+    static final AmediaRequestParametere DAWN_OF_TIME = new AmediaRequestParametere(DAWN_OF_TIME_LOCALDATETIME, false, 10000);
+    static final AmediaRequestParametere PING = new AmediaRequestParametere(LocalDateTime.now(), false, 1);
+
+    AmediaRequestParametere(LocalDateTime sisteModifiedDate, boolean medInnhold, int resultSize) {
         this.sisteModifiedDate = modifisertDatoMedBuffertid(sisteModifiedDate);
         this.transactionType = DEFAULT_TRANSACTION_TYPE;
         this.sortering = DEFAULT_SORTERING;

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaResponseMapper.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaResponseMapper.java
@@ -18,7 +18,9 @@ class AmediaResponseMapper {
         List<JsonNode> hitlist = Lists.newArrayList(hits.iterator());
 
         return hitlist.stream()
-            .map(h -> new AmediaStillingMapper(h).getStilling())
+                .map(AmediaStillingMapper::new)
+                .filter(amediaStilling -> !amediaStilling.isFromNav())
+                .map(amediaStilling -> amediaStilling.getStilling())
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaService.java
@@ -56,7 +56,7 @@ public class AmediaService {
         ExternalRun externalRun = externalRunService.findByNameAndMedium(Kilde.AMEDIA.toString(), Kilde.AMEDIA.value());
 
         List<String> alleStillingIDerFraAmedia = AmediaResponseMapper.mapEksternIder(
-                amediaConnector.hentData(AmediaDateConverter.getInitialDate(), false, 10000));
+                amediaConnector.hentData(AmediaRequestParametere.DAWN_OF_TIME));
 
         List<Stilling> returnerteStillingerFraAmedia = hentAmediaData(getLastRun(externalRun));
         LOG.info("Amediameldinger hentet fra api: {}", returnerteStillingerFraAmedia.size());
@@ -129,8 +129,9 @@ public class AmediaService {
     }
 
     private List<Stilling> hentAmediaData(LocalDateTime sisteModifiserteDato) {
+        AmediaRequestParametere requestParametere = new AmediaRequestParametere(sisteModifiserteDato, true, MAXANTALl_TREFF);
         return AmediaResponseMapper
-                .mapResponse(amediaConnector.hentData(sisteModifiserteDato, true, MAXANTALl_TREFF));
+                .mapResponse(amediaConnector.hentData(requestParametere));
     }
 
 

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaStillingMapper.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaStillingMapper.java
@@ -100,6 +100,11 @@ class AmediaStillingMapper {
         return stilling;
     }
 
+    boolean isFromNav() {
+
+        return text(source.get("created_by")).equals("nav");
+    }
+
     private String getStedMedSoner() {
         return amediaFieldTransformer.reservefelt(
                 text(address.get("geography")),


### PR DESCRIPTION
 slik at vi unngår at stillingene går i loop mellom amedia og nav + noe refaktorering

Dette er en java variant av kotlin-PRen slik at man får sammenligningsgrunnlaget som ble etterspurt av @oyvindstegard.