### PR TITLE
Bruk json liste for arbeidspråk

### DIFF
--- a/src/main/java/no/nav/pam/annonsemottak/receivers/finn/FinnAdMapper.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/finn/FinnAdMapper.java
@@ -119,7 +119,7 @@ class FinnAdMapper {
         keyValueMap.put(PropertyNames.EMPLOYER_URL, ad.getCompany().getUrl());
         keyValueMap.put(PropertyNames.KEYWORDS, concatenate(ad.getKeywords()));
         keyValueMap.put(PropertyNames.OCCUPATIONS, concatenate(ad.getOccupations(), ";"));
-        keyValueMap.put(PropertyNames.ARBEIDSPRAAK, concatenate(ad.getWorkingLanguage()));
+        keyValueMap.put(PropertyNames.ARBEIDSPRAAK, toJsonString(ad.getWorkingLanguage()));
         keyValueMap.put("managerRole", ad.getManagerRole());
         keyValueMap.put("providerId", ad.getProviderId());
         keyValueMap.put("situation", ad.getSituation());

--- a/src/test/java/no/nav/pam/annonsemottak/receivers/finn/FinnAdMapperTest.java
+++ b/src/test/java/no/nav/pam/annonsemottak/receivers/finn/FinnAdMapperTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 
 import java.io.Reader;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -173,17 +174,17 @@ public class FinnAdMapperTest {
         try (Reader reader = FinnConnectorTest.getReader(AD1)) {
             Stilling stilling = FinnAdMapper.toStilling(new FinnAd(connector.parseReaderToDocument(reader)));
             assertNotNull(stilling);
-            assertEquals("Engelsk,Norsk", stilling.getProperties().get(PropertyNames.ARBEIDSPRAAK));
+            assertEquals("[\"Engelsk\",\"Norsk\"]", stilling.getProperties().get(PropertyNames.ARBEIDSPRAAK));
         }
         try (Reader reader = FinnConnectorTest.getReader(AD2)) {
             Stilling stilling = FinnAdMapper.toStilling(new FinnAd(connector.parseReaderToDocument(reader)));
             assertNotNull(stilling);
-            assertEquals("Norsk", stilling.getProperties().get(PropertyNames.ARBEIDSPRAAK));
+            assertEquals("[\"Norsk\"]", stilling.getProperties().get(PropertyNames.ARBEIDSPRAAK));
         }
         try (Reader reader = FinnConnectorTest.getReader(AD3)) {
             Stilling stilling = FinnAdMapper.toStilling(new FinnAd(connector.parseReaderToDocument(reader)));
             assertNotNull(stilling);
-            assertEquals(null, stilling.getProperties().get(PropertyNames.ARBEIDSPRAAK));
+            assertEquals("[]", stilling.getProperties().get(PropertyNames.ARBEIDSPRAAK));
         }
     }
 }


### PR DESCRIPTION
Vi trenger å levere arbeidspråk data som json liste, altså:

`"[\"Engelsk\",\"Norsk\"]"`

Så bare en liten endring for å få det til.