### PR TITLE
Keep <section> tags when sanitizing HTML, generated from Markdown

### DIFF
--- a/src/main/java/no/nav/pam/annonsemottak/markdown/HtmlSanitizer.java
+++ b/src/main/java/no/nav/pam/annonsemottak/markdown/HtmlSanitizer.java
@@ -1,16 +1,23 @@
 package no.nav.pam.annonsemottak.markdown;
 
+import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
 import org.owasp.html.Sanitizers;
 
 public class HtmlSanitizer {
 
     public static String sanitize(String html){
+        PolicyFactory allowSectionTags = new HtmlPolicyBuilder()
+                .allowElements("section")
+                .allowAttributes("id").onElements("section")
+                .toFactory();
+
         PolicyFactory policy = Sanitizers.FORMATTING
                 .and(Sanitizers.LINKS)
                 .and(Sanitizers.BLOCKS)
                 .and(Sanitizers.TABLES)
-                .and(Sanitizers.FORMATTING);
+                .and(Sanitizers.FORMATTING)
+                .and(allowSectionTags);
 
         return policy.sanitize(html);
     }

--- a/src/test/java/no/nav/pam/annonsemottak/markdown/MarkdownToHtmlConverterTest.java
+++ b/src/test/java/no/nav/pam/annonsemottak/markdown/MarkdownToHtmlConverterTest.java
@@ -135,4 +135,35 @@ public class MarkdownToHtmlConverterTest {
                 "<ul><li>Personal, resultat og budsjettansvar</li>"));
     }
 
+    @Test
+    public void parse_markdownWithSection() {
+        String markdown = "Seksjoner\n" +
+                "<section id=\"en\">\n" +
+                "\n" +
+                "## Seksjon 1\n" +
+                "*Ting i seksjon* - cool!\n" +
+                "\n" +
+                "</section>\n" +
+                "Utenfor seksjon\n" +
+                "\n" +
+                "<section id=\"to\">\n" +
+                "\n" +
+                "### Seksjon 2\n" +
+                "\n" +
+                "</section>\n";
+
+        String expected = "<p>Seksjoner</p>\n" +
+                "<section id=\"en\">\n" +
+                "<h2>Seksjon 1</h2>\n" +
+                "<p><em>Ting i seksjon</em> - cool!</p>\n" +
+                "</section>\n" +
+                "Utenfor seksjon\n" +
+                "<section id=\"to\">\n" +
+                "<h3>Seksjon 2</h3>\n" +
+                "</section>\n";
+
+        assertEquals(expected, MarkdownToHtmlConverter.parse(markdown));
+    }
+
+
 }


### PR DESCRIPTION
Allow `<section>` tags with `id` attributes when sanitizing HTML.

Use case for this is to be able to distinguish between different sections in ad text, to allow structuring ads based on these sections.