### PR TITLE
Retter feil som gjorde at vi ikke får inn stillinger fra Amedia hvis et felt er for langt

### DIFF
--- a/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaService.java
@@ -43,7 +43,9 @@ public class AmediaService {
         felter.put("place", s.getPlace());
         felter.put("title", s.getTitle());
         felter.put("duedate", s.getDueDate());
-        felter.put("employer", s.getEmployerDescription());
+        if(s.getArbeidsgiver().isPresent()) {
+            felter.put("employer", s.getArbeidsgiver().get().asString());
+        }
         felter.put("hash", s.getHash());
         if (s.getMerknader().isPresent()) {
             felter.put("merknader", s.getMerknader().get().asString());

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/amedia/AmediaService.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Amedia operasjoner
@@ -34,25 +33,27 @@ public class AmediaService {
     private final ExternalRunService externalRunService;
     private final AnnonseMottakProbe probe;
 
-    private void logFeltlengder(Stilling s) {
-        var felter = new HashMap<String, Integer>();
-        felter.put("createdby", s.getCreatedBy().length());
-        felter.put("updatedby", s.getUpdatedBy().length());
-        felter.put("createdbydisplayname", s.getCreatedByDisplayName().length());
-        felter.put("updatedbydisplayname", s.getUpdatedByDisplayName().length());
-        felter.put("externalid", s.getExternalId().length());
-        felter.put("place", s.getPlace().length());
-        felter.put("title", s.getTitle().length());
-        felter.put("duedate", s.getDueDate().length());
-        felter.put("employer", s.getEmployerDescription().length());
-        felter.put("hash", s.getHash().length());
-        felter.put("merknader", s.getMerknader().isPresent() ? s.getMerknader().get().asString().length() : 0);
+    public static void logFeltlengder(Stilling s) {
+        var felter = new HashMap<String, String>();
+        felter.put("createdby", s.getCreatedBy());
+        felter.put("updatedby", s.getUpdatedBy());
+        felter.put("createdbydisplayname", s.getCreatedByDisplayName());
+        felter.put("updatedbydisplayname", s.getUpdatedByDisplayName());
+        felter.put("externalid", s.getExternalId());
+        felter.put("place", s.getPlace());
+        felter.put("title", s.getTitle());
+        felter.put("duedate", s.getDueDate());
+        felter.put("employer", s.getEmployerDescription());
+        felter.put("hash", s.getHash());
+        if (s.getMerknader().isPresent()) {
+            felter.put("merknader", s.getMerknader().get().asString());
+        }
 
         // hvis et felt er over 254 tegn, logg det
         felter.entrySet().stream()
-                .filter(e -> e.getValue() > 254)
-                .forEach(e -> LOG.warn("Annonnse med externalid {} og id {} har feltet {} lengde {}",
-                        s.getExternalId(), s.getId(), e.getKey(), e.getValue()));
+                .filter(e -> e.getValue() != null && e.getValue().length() > 254)
+                .forEach(e -> LOG.warn("Annonnse med externalid '{}' og id '{}' har feltet '{}' lengde {} verdi: '{}'",
+                        s.getExternalId(), s.getId(), e.getKey(), e.getValue().length(), e.getValue()));
 
     }
 

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/finn/scheduler/FinnSchedulerTask.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/finn/scheduler/FinnSchedulerTask.java
@@ -1,6 +1,5 @@
 package no.nav.pam.annonsemottak.receivers.finn.scheduler;
 
-import jakarta.inject.Inject;
 import net.javacrumbs.shedlock.core.SchedulerLock;
 import no.nav.pam.annonsemottak.receivers.finn.FinnService;
 import org.slf4j.Logger;

--- a/src/main/java/no/nav/pam/annonsemottak/stilling/Stilling.java
+++ b/src/main/java/no/nav/pam/annonsemottak/stilling/Stilling.java
@@ -126,7 +126,7 @@ public class Stilling extends ModelEntity {
     }
 
     void addProperties(Map<String, String> properties) {
-        if(properties != null) {
+        if (properties != null) {
             this.properties.putAll(properties);
         }
     }
@@ -279,10 +279,39 @@ public class Stilling extends ModelEntity {
         return this;
     }
 
+    public List<Map.Entry<String, String>> felterSomOverstigerGrensenPaa255Tegn() {
+        var felter = new HashMap<String, String>();
+        felter.put("createdby", getCreatedBy());
+        felter.put("updatedby", getUpdatedBy());
+        felter.put("createdbydisplayname", getCreatedByDisplayName());
+        felter.put("updatedbydisplayname", getUpdatedByDisplayName());
+        felter.put("externalid", getExternalId());
+        felter.put("place", getPlace());
+        felter.put("title", getTitle());
+        felter.put("duedate", getDueDate());
+        if (getArbeidsgiver().isPresent()) {
+            felter.put("employer", getArbeidsgiver().get().asString());
+        }
+        felter.put("hash", getHash());
+        if (getMerknader().isPresent()) {
+            felter.put("merknader", getMerknader().get().asString());
+        }
+
+        return finnFelterSomOverstigerFeltlengden(felter, 255);
+    }
+
+    private List<Map.Entry<String, String>> finnFelterSomOverstigerFeltlengden(HashMap<String, String> felter, int feltlengde) {
+        return felter.entrySet().stream()
+                .filter(e -> e.getValue() != null && e.getValue().length() >= feltlengde)
+                .toList();
+    }
+
     @Override
     public String toString() {
         return "[UUID: " + uuid + "]" +
                 "[Arbeidsgiver: " + employer + "]" +
-                "[Annonsetittel: " + title + "]";
+                "[Annonsetittel: " + title + "]" +
+                "[Kilde: " + kilde + "]" +
+                "[Medium: " + medium + "]";
     }
 }

--- a/src/test/java/no/nav/pam/annonsemottak/receivers/amedia/rest/AmediaApiTest.java
+++ b/src/test/java/no/nav/pam/annonsemottak/receivers/amedia/rest/AmediaApiTest.java
@@ -8,6 +8,7 @@ import no.nav.pam.annonsemottak.stilling.StillingRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +77,7 @@ public class AmediaApiTest {
     /*
         Tester api, paramtereren til Amedia, og at alt utenom repoene er wiret opp.
      */
+    @Disabled // TODO: midlertidig deaktivert
     @Test
     public void en_ny_amedia_stilling() throws Exception {
         MvcResult mvcResult = this.mvc.perform(

--- a/src/test/java/no/nav/pam/annonsemottak/receivers/amedia/rest/AmediaApiTest.java
+++ b/src/test/java/no/nav/pam/annonsemottak/receivers/amedia/rest/AmediaApiTest.java
@@ -103,7 +103,7 @@ public class AmediaApiTest {
         Stilling stilling = new Stilling(
                 forLangtFelt,
                 akkuratForLang,
-                "Mock Employer",
+                forLangtFelt,
                 akkuratPasse,
                 "Mock Job Description",
                 "2023-12-31",

--- a/src/test/java/no/nav/pam/annonsemottak/receivers/amedia/rest/AmediaApiTest.java
+++ b/src/test/java/no/nav/pam/annonsemottak/receivers/amedia/rest/AmediaApiTest.java
@@ -29,6 +29,7 @@ import java.io.InputStreamReader;
 import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -45,6 +46,9 @@ public class AmediaApiTest {
 
     @Autowired
     protected MockMvc mvc;
+
+    @Autowired
+    private AmediaService amediaService;
 
     @BeforeAll
     public static void initStubs() {
@@ -96,7 +100,7 @@ public class AmediaApiTest {
     }
 
     @Test
-    public void logg_hvis_har_for_langt_felt() {
+    public void valider_feltlengder_paa_255_tegn() {
         String forLangtFelt = "A".repeat(300);
         String akkuratForLang = "B".repeat(255);
         String akkuratPasse = "C".repeat(254);
@@ -112,7 +116,7 @@ public class AmediaApiTest {
                 "http://mock.url",
                 "MockExternalId"
         );
-        AmediaService.logFeltlengder(stilling);
+        assertFalse(amediaService.erFelteneInnenForTillatLengde(stilling));
     }
 
 }

--- a/src/test/java/no/nav/pam/annonsemottak/receivers/amedia/rest/AmediaApiTest.java
+++ b/src/test/java/no/nav/pam/annonsemottak/receivers/amedia/rest/AmediaApiTest.java
@@ -4,11 +4,12 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import no.nav.pam.annonsemottak.Application;
 import no.nav.pam.annonsemottak.PathDefinition;
 import no.nav.pam.annonsemottak.receivers.amedia.AmediaResponseMapperTest;
+import no.nav.pam.annonsemottak.receivers.amedia.AmediaService;
+import no.nav.pam.annonsemottak.stilling.Stilling;
 import no.nav.pam.annonsemottak.stilling.StillingRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,7 +78,6 @@ public class AmediaApiTest {
     /*
         Tester api, paramtereren til Amedia, og at alt utenom repoene er wiret opp.
      */
-    @Disabled // TODO: midlertidig deaktivert
     @Test
     public void en_ny_amedia_stilling() throws Exception {
         MvcResult mvcResult = this.mvc.perform(
@@ -94,4 +94,25 @@ public class AmediaApiTest {
 
         s.assertAll();
     }
+
+    @Test
+    public void logg_hvis_har_for_langt_felt() {
+        String forLangtFelt = "A".repeat(300);
+        String akkuratForLang = "B".repeat(255);
+        String akkuratPasse = "C".repeat(254);
+        Stilling stilling = new Stilling(
+                forLangtFelt,
+                akkuratForLang,
+                "Mock Employer",
+                akkuratPasse,
+                "Mock Job Description",
+                "2023-12-31",
+                "Mock Kilde",
+                "Mock Medium",
+                "http://mock.url",
+                "MockExternalId"
+        );
+        AmediaService.logFeltlengder(stilling);
+    }
+
 }


### PR DESCRIPTION
Feilen gjorde at hele jobben feilet, hvis en annonse hadde et feilt med feil lengde.

Filtrerer bort og logger annonser som har feil feltlengde. I dette tilfellet var det puttet inn hele annonse teksten inn i feltet `place`.

Har verifisert at dette fungerer i dev, da det var samme problemet det som i prod.

Ønsker bare å få denne raskt ut, så kan koden gjøres litt ryddigere etterpå.