### PR TITLE
Splitt opp saveAll i mindre batcher da dette nå tryner ved henting av alle annonser på ny (10.000 stk)

### DIFF
--- a/src/main/java/no/nav/pam/annonsemottak/receivers/fangst/AnnonseFangstService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/fangst/AnnonseFangstService.java
@@ -88,6 +88,12 @@ public class AnnonseFangstService {
     }
 
     @Transactional
+    public void saveBatch(List<Stilling> stillinger) {
+        LOG.info("Saving batch of {} ads", stillinger.size());
+        stillinger.forEach(this::saveOne);
+    }
+
+    @Transactional
     public void saveOne(Stilling s) {
         try {
             Stilling lagretStilling = stillingRepository.save(s);

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/finn/FinnService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/finn/FinnService.java
@@ -16,8 +16,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -50,10 +48,11 @@ public class FinnService {
         this.probe = probe;
     }
 
+    private static final int BATCH_SIZE = 500;
+
     /**
      * Will retrieve all the active job ads from finn, and save new or changed ads.
      */
-    @Transactional
     public ResultsOnSave saveAndUpdateFromCollection() throws FinnConnectorException {
 
         //Retrieve the date for last successful run
@@ -113,8 +112,16 @@ public class FinnService {
 
         LOG.debug("Saving Finn ads");
         List<Stilling> newList = annonseResult.getNewList();
-        finnAnnonseFangstService.saveAll(new AnnonseResult(annonseResult.getModifyList(), annonseResult.getStopList(),
-                annonseResult.getExpiredList(), newList, annonseResult.getDuplicateList()));
+        AnnonseResult fullResult = new AnnonseResult(annonseResult.getModifyList(), annonseResult.getStopList(),
+                annonseResult.getExpiredList(), newList, annonseResult.getDuplicateList());
+
+        List<Stilling> allStillinger = fullResult.getAll();
+        int totalBatches = (int) Math.ceil((double) allStillinger.size() / BATCH_SIZE);
+        for (int i = 0; i < allStillinger.size(); i += BATCH_SIZE) {
+            List<Stilling> batch = allStillinger.subList(i, Math.min(i + BATCH_SIZE, allStillinger.size()));
+            LOG.info("Saving batch {}/{} ({} ads)", (i / BATCH_SIZE) + 1, totalBatches, batch.size());
+            finnAnnonseFangstService.saveBatch(batch);
+        }
 
         //Save new or update last run time
         externalRunService.save(externalRun);

--- a/src/main/java/no/nav/pam/annonsemottak/receivers/finn/FinnService.java
+++ b/src/main/java/no/nav/pam/annonsemottak/receivers/finn/FinnService.java
@@ -90,9 +90,6 @@ public class FinnService {
             retrievedAds = connector.fetchFullAds(searchResult);
         }
 
-        int antallJobSourceDirect = retrievedAds.stream().filter(it -> "direct".equals(it.getJobSource())).toList().size();
-        LOG.info("Antall annonser med jobSource 'direct': {} / {}", antallJobSourceDirect, retrievedAds.size());
-
         // Retrieve filtered ads in detail
         List<Stilling> filteredStillingList = retrievedAds.stream()
                 .map(FinnAdMapper::toStilling)
@@ -106,9 +103,6 @@ public class FinnService {
 
         LOG.debug("Process finn result");
         AnnonseResult annonseResult = finnAnnonseFangstService.retrieveAnnonseLists(filteredStillingList, allExternalIds, Kilde.FINN.toString(), Medium.FINN.toString());
-
-        // TODO: Fjern dette når NKS ser at vi ikke får for mange duplikater
-        loggAnnonserSomTidligereBleFiltrertUt(annonseResult);
 
         LOG.debug("Saving Finn ads");
         List<Stilling> newList = annonseResult.getNewList();


### PR DESCRIPTION
Jeg tok bort @Transactional fra saveAndUpdateFromCollection(), og flyttet den til saveBatch()

Jeg fjernet også logging vi ikke trenger lengre. 