### PR TITLE
Legg til CI-workflow som verifiserer PR-er mot master

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -1,0 +1,25 @@
+name: Verify PR
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "**.md"
+      - ".gitignore"
+      - "LICENCE"
+      - "CODEOWNERS"
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: temurin
+          cache: maven
+      - name: Build and verify
+        run: ./build.sh


### PR DESCRIPTION
Kjører `./build.sh` (`mvn clean verify`) på alle PR-er mot `master`, slik at endringer – inkludert Dependabot-oppdateringer – bygges og testes før merge.