### PR TITLE
chore: juster CPU-ressurser og fjern CPU-grense

### DIFF
--- a/naiserator.yml
+++ b/naiserator.yml
@@ -20,11 +20,10 @@ spec:
     cpuThresholdPercentage: 50
   resources:
     limits:
-      cpu: 2000m
       memory: 1500Mi
     requests:
-      cpu: 500m
-      memory: 500Mi
+      cpu: 113m
+      memory: 768Mi
   prometheus:
     enabled: true
     path: /actuator/prometheus


### PR DESCRIPTION
Appens ressursinnstillinger er betydelig overprovisionert i forhold til faktisk bruk, noe som sloser med klusterressurser.

Undersokelse med `kubectl top pod` viste CPU-bruk pa 2-5m i hvilemodus (mot en request pa 500m), og arbeidsmengden forblir I/O-bundet selv under daglige batch-kjoeringer (Finn, Amedia, deaktivering av utlopte annonser). Fjerning av CPU-grensen lar pods bruke mer CPU ved behov.

**Endringer:**

- **CPU request:** 500m -> 113m (i trad med Nais-anbefaling)
- **CPU limit:** fjernet (ikke anbefalt ifolge [Nais-dokumentasjon](https://docs.nais.io/workloads/explanations/good-practices/?h=limit#set-reasonable-resource-requests-and-limits))
- **Memory request:** 500Mi -> 768Mi (bedre gjenspeiler faktisk baseline)
- **Memory limit:** beholdt pa 1500Mi -- en pod ble observert pa 1090Mi pga. JVM heap-skalering (`MaxRAMPercentage=70` i Dockerfile), sa den anbefalte verdien pa 1088Mi ville forarsake OOM-kills