### PR TITLE
Flytt brukernavn og passord ut av JDBC-URL

### DIFF
--- a/src/main/resources/application-prod-url.yml
+++ b/src/main/resources/application-prod-url.yml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}

--- a/src/main/resources/application-prod-url.yml
+++ b/src/main/resources/application-prod-url.yml
@@ -1,3 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,8 @@
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     hikari:
       maximum-pool-size: 5
       minimum-idle: 0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,3 @@ finn:
   job-parttime-url: https://cache.api.finn.no/iad/search/job-part-time/
   api:
     password: ${FINN_API_PASSWORD:}
-
-logging:
-  level:
-    org.hibernate.orm.connections.pooling: WARN

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,7 +5,6 @@
     </appender>
 
     <logger name="org.hibernate.engine.internal.StatisticalLoggingSessionEventListener" level="OFF" />
-    <logger name="org.hibernate.orm.connections.pooling" level="warn"/>
 
     <root level="INFO">
         <appender-ref ref="stdout_json" />


### PR DESCRIPTION
## Hvorfor
Hibernate of Flyway logger JDBC-URL ved oppstart. Da kan ikke brukernavn og passord ligge i URL-en (Flyway sensorerer passordet, men ikke Hibernate).

## Endring
- `spring.datasource.url` inneholder nå kun host, port og databasenavn.
- `spring.datasource.username` og `spring.datasource.password` brukes for brukernavn og passord.
- Logger-overstyring for `org.hibernate.orm.connections.pooling` er fjernet fra `application.yml` og `logback.xml`.

## Resultat
Oppstartslogger fra flyway og hibernate viser ikke lenger brukernavn og passord query params fra url.