### PR TITLE
Skru på OpenTelemetry auto-instrumentering for NAIS APM

### DIFF
--- a/naiserator.yml
+++ b/naiserator.yml
@@ -28,6 +28,9 @@ spec:
     enabled: true
     path: /actuator/prometheus
   observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
     logging:
       destinations:
         - id: loki


### PR DESCRIPTION
## Hvorfor

Appen dukker opp i Grafana med kun logger, og ingenting i [NAIS APM](https://grafana.nav.cloud.nais.io/a/nais-apm-app/services/teampam/pam-annonsemottak). APM er en egen pipeline fra Prometheus: `micrometer-registry-prometheus` gir rå metrikker i Explore, mens APM-dashboardene (RED-metrikker, traces, avhengighetskart) drives av OpenTelemetry auto-instrumentering, som ikke var skrudd på.

## Hva

Legger til `observability.autoInstrumentation` (`runtime: java`) i `naiserator.yml`. NAIS injiserer OpenTelemetry Java-agenten via `JAVA_TOOL_OPTIONS` ved oppstart, så ingen kode- eller avhengighetsendringer trengs. Gir traces og runtime-metrikker fra Spring MVC, JDBC/Postgres, Kafka og OkHttp.

Se [NAIS-dokumentasjonen om auto-instrumentering](https://docs.nais.io/observability/how-to/auto-instrumentation/).
