### PR TITLE
Bytt til JDK_JAVA_OPTIONS i Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 COPY target/pam-annonsemottak-*.jar /app/app.jar
 
 ENV SPRING_PROFILES_ACTIVE=prod
-ENV JAVA_TOOL_OPTIONS="-XX:InitialRAMPercentage=25 -XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
+ENV JDK_JAVA_OPTIONS="-XX:InitialRAMPercentage=25 -XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
 ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
 
 EXPOSE 9016


### PR DESCRIPTION
Bytter fra JAVA_TOOL_OPTIONS til JDK_JAVA_OPTIONS i Dockerfile.
NAIS auto-instrumentering injiserer JAVA_TOOL_OPTIONS med -javaagent, som kan overstyre JVM-flaggene våre. Dette fjerner konflikten når auto-instrumentering er aktivert.